### PR TITLE
Enhance CLI help display with rich help panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 *NOTE:* Version 0.X.X might have breaking changes in bumps of the minor version number. This is because the project is still in early development and the API is not yet stable. It will still be marked clearly in the release notes.
 
+## [0.5.0] - 24-09-2025
+- Improvements to the plugin system. Plugins can choose their own names and the plugins is show in a seperate section in the rich help panel.
+
 ## [0.4.0] - 14-09-2025
 - Add ability to customize configurations in a toolit.ini or pyproject.toml file in the project root. Makes the devtools folder configurable, and allows plugins to add their own configurations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]  
 name = "toolit"  
-version = "0.4.0"  
+version = "0.5.0"  
 description = "MCP Server, Typer CLI and vscode tasks in one, provides an easy way to configure your own DevTools and python scripts in a project."
 readme = "README.md"
 requires-python = ">=3.9"  # mcp[cli] requires Python 3.10+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ build-backend = "setuptools.build_meta"
 packages = ["toolit"]  
 
 [tool.setuptools.package-data]
-snappylapy = ["py.typed"]
+toolit = ["py.typed"]

--- a/toolit/__init__.py
+++ b/toolit/__init__.py
@@ -1,7 +1,7 @@
 """Public API for the package."""
 
-from .config import get_config_value
-from .decorators import tool
+from toolit.config import get_config_value
+from toolit.decorators import tool
 
 __all__ = [
     "get_config_value",

--- a/toolit/auto_loader.py
+++ b/toolit/auto_loader.py
@@ -56,7 +56,7 @@ def load_tools_from_plugins() -> list[FunctionType]:
     """Discover and return plugin commands via entry points."""
     plugins = get_plugin_tools()
     for plugin in plugins:
-        register_command(plugin)
+        register_command(plugin, rich_help_panel="Commands from Plugins")
     return plugins
 
 
@@ -83,7 +83,7 @@ def load_tools_from_folder(folder_path: pathlib.Path) -> list[FunctionType]:
     tool_groups: list[FunctionType] = get_items_from_folder(folder_path, tool_group_strategy)
     # Register each tool as a command
     for tool in tools:
-        register_command(tool)
+        register_command(tool, rich_help_panel="Commands Local Tools")
     return tools + tool_groups
 
 
@@ -124,5 +124,6 @@ def get_plugin_tools() -> list[FunctionType]:
     plugins = []
     for entry_point in importlib.metadata.entry_points().get("toolit_plugins", []):
         plugin_func: Any = entry_point.load()
+        plugin_func.__name__ = entry_point.name
         plugins.append(plugin_func)
     return plugins

--- a/toolit/auto_loader.py
+++ b/toolit/auto_loader.py
@@ -13,7 +13,7 @@ import inspect
 import pathlib
 import importlib
 import importlib.metadata
-from toolit.constants import MARKER_TOOL, ToolitTypesEnum
+from toolit.constants import MARKER_TOOL, RichHelpPanelNames, ToolitTypesEnum
 from toolit.create_apps_and_register import register_command
 from types import FunctionType, ModuleType
 from typing import Any, Callable
@@ -56,7 +56,7 @@ def load_tools_from_plugins() -> list[FunctionType]:
     """Discover and return plugin commands via entry points."""
     plugins = get_plugin_tools()
     for plugin in plugins:
-        register_command(plugin, rich_help_panel="Commands from Plugins")
+        register_command(plugin, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS)
     return plugins
 
 
@@ -83,7 +83,7 @@ def load_tools_from_folder(folder_path: pathlib.Path) -> list[FunctionType]:
     tool_groups: list[FunctionType] = get_items_from_folder(folder_path, tool_group_strategy)
     # Register each tool as a command
     for tool in tools:
-        register_command(tool, rich_help_panel="Commands Local Tools")
+        register_command(tool, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PROJECT)
     return tools + tool_groups
 
 

--- a/toolit/auto_loader.py
+++ b/toolit/auto_loader.py
@@ -56,7 +56,7 @@ def load_tools_from_plugins() -> list[FunctionType]:
     """Discover and return plugin commands via entry points."""
     plugins = get_plugin_tools()
     for plugin in plugins:
-        register_command(plugin, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS)
+        register_command(plugin, rich_help_panel=RichHelpPanelNames.PLUGINS_COMMANDS_PANEL)
     return plugins
 
 
@@ -83,7 +83,7 @@ def load_tools_from_folder(folder_path: pathlib.Path) -> list[FunctionType]:
     tool_groups: list[FunctionType] = get_items_from_folder(folder_path, tool_group_strategy)
     # Register each tool as a command
     for tool in tools:
-        register_command(tool, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PROJECT)
+        register_command(tool, rich_help_panel=RichHelpPanelNames.PROJECT_COMMANDS_PANEL)
     return tools + tool_groups
 
 

--- a/toolit/cli.py
+++ b/toolit/cli.py
@@ -1,12 +1,13 @@
 """CLI entry point for the toolit package."""
-from .auto_loader import load_tools_from_folder, load_tools_from_plugins, register_command
-from .config import load_devtools_folder
-from .create_apps_and_register import app
-from .create_tasks_json import create_vscode_tasks_json
+from toolit.auto_loader import load_tools_from_folder, load_tools_from_plugins, register_command
+from toolit.config import load_devtools_folder
+from toolit.constants import RichHelpPanelNames
+from toolit.create_apps_and_register import app
+from toolit.create_tasks_json import create_vscode_tasks_json
 
 load_tools_from_folder(load_devtools_folder())
 load_tools_from_plugins()
-register_command(create_vscode_tasks_json)
+register_command(create_vscode_tasks_json, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS)
 
 
 if __name__ == "__main__":

--- a/toolit/cli.py
+++ b/toolit/cli.py
@@ -7,7 +7,7 @@ from toolit.create_tasks_json import create_vscode_tasks_json
 
 load_tools_from_folder(load_devtools_folder())
 load_tools_from_plugins()
-register_command(create_vscode_tasks_json, rich_help_panel=RichHelpPanelNames.NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS)
+register_command(create_vscode_tasks_json, rich_help_panel=RichHelpPanelNames.PLUGINS_COMMANDS_PANEL)
 
 
 if __name__ == "__main__":

--- a/toolit/config.py
+++ b/toolit/config.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import toml
 import pathlib
-from .constants import ConfigFileKeys
 from functools import lru_cache
+from toolit.constants import ConfigFileKeys
 from typing import Callable, overload
 
 

--- a/toolit/constants.py
+++ b/toolit/constants.py
@@ -5,6 +5,13 @@ import enum
 MARKER_TOOL = "__toolit_tool_type__"
 
 
+class RichHelpPanelNames:
+    """Namespace for the different rich help panel names."""
+
+    NAME_OF_THE_RICH_GROUP_HELP_PANEL_PROJECT = "Commands from Project"
+    NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS = "Commands from Plugins"
+
+
 class ConfigFileKeys:
     """Namespace for the different configuration file keys for user configuration."""
 

--- a/toolit/constants.py
+++ b/toolit/constants.py
@@ -8,8 +8,8 @@ MARKER_TOOL = "__toolit_tool_type__"
 class RichHelpPanelNames:
     """Namespace for the different rich help panel names."""
 
-    NAME_OF_THE_RICH_GROUP_HELP_PANEL_PROJECT = "Commands from Project"
-    NAME_OF_THE_RICH_GROUP_HELP_PANEL_PLUGINS = "Commands from Plugins"
+    PROJECT_COMMANDS_PANEL = "Commands from Project"
+    PLUGINS_COMMANDS_PANEL = "Commands from Plugins"
 
 
 class ConfigFileKeys:

--- a/toolit/create_apps_and_register.py
+++ b/toolit/create_apps_and_register.py
@@ -29,7 +29,11 @@ def initialize() -> None:
     """Welcome to the Toolit CLI."""
 
 
-def register_command(command_func: Callable[..., Any], name: str | None = None, rich_help_panel: str|None = None) -> None:
+def register_command(
+    command_func: Callable[..., Any],
+    name: str | None = None,
+    rich_help_panel: str | None = None,
+) -> None:
     """Register an external command to the CLI and MCP server if available."""
     if not callable(command_func):
         msg = f"Command function {command_func} is not callable."

--- a/toolit/create_apps_and_register.py
+++ b/toolit/create_apps_and_register.py
@@ -29,11 +29,11 @@ def initialize() -> None:
     """Welcome to the Toolit CLI."""
 
 
-def register_command(command_func: Callable[..., Any], name: str | None = None) -> None:
+def register_command(command_func: Callable[..., Any], name: str | None = None, rich_help_panel: str|None = None) -> None:
     """Register an external command to the CLI and MCP server if available."""
     if not callable(command_func):
         msg = f"Command function {command_func} is not callable."
         raise TypeError(msg)
-    app.command(name=name)(command_func)
+    app.command(name=name, rich_help_panel=rich_help_panel)(command_func)
     if mcp is not None:
         mcp.tool(name)(command_func)

--- a/toolit/decorators.py
+++ b/toolit/decorators.py
@@ -1,6 +1,6 @@
 """Decorator to tell if a function is a tool."""
 
-from .constants import MARKER_TOOL, ToolitTypesEnum
+from toolit.constants import MARKER_TOOL, ToolitTypesEnum
 from typing import Any, Callable, TypeVar
 
 T = TypeVar("T", bound=Callable[..., Any])


### PR DESCRIPTION
Introduce a new parameter for command registration to improve the CLI help display by categorizing commands into rich help panels for plugins and projects. Update the version and changelog accordingly.